### PR TITLE
make only the label editable for any question with attribute isACoreQ…

### DIFF
--- a/components/EventIntakeQuestions/index.tsx
+++ b/components/EventIntakeQuestions/index.tsx
@@ -82,32 +82,38 @@ const EventIntakeQuestions: React.FC<{
                   <Typography style={{ marginBottom: 10 }}>
                     {"Question " + (intakeQuestionIdx + 1) + ". "}
                   </Typography>
-                  <Button
-                    style={{ marginBottom: 10 }}
-                    data-testid={"collection-details-submit-button"}
-                    variant="contained"
-                    onClick={() => {
-                      deleteIntakeQuestion(intakeQuestionIdx);
-                    }}
-                  >
-                    <FormattedMessage
-                      id="REMOVE_QUESTION"
-                      defaultMessage="Remove this question"
-                    />
-                  </Button>
+                  {!wholeQuestion?.isACoreQuestion && (
+                    <Button
+                      style={{ marginBottom: 10 }}
+                      data-testid={"collection-details-submit-button"}
+                      variant="contained"
+                      onClick={() => {
+                        deleteIntakeQuestion(intakeQuestionIdx);
+                      }}
+                    >
+                      <FormattedMessage
+                        id="REMOVE_QUESTION"
+                        defaultMessage="Remove this question"
+                      />
+                    </Button>
+                  )}
                 </>
               )}
-              <SingleEventIntakeQuestion
-                key={intakeQuestionKey}
-                intakeQuestionEl={intakeQuestionEl}
-                intakeQuestionKey={intakeQuestionKey}
-                wholeQuestion={wholeQuestion}
-                intakeQuestionsInvalid={intakeQuesionsInvalid}
-                intakeQuestionIdx={intakeQuestionIdx}
-                collection={collection}
-                setCollection={setCollection}
-                formFieldGroup={formFieldGroup}
-              />
+              {(!wholeQuestion?.isACoreQuestion ||
+                (intakeQuestionKey === "label" &&
+                  wholeQuestion?.isACoreQuestion)) && (
+                <SingleEventIntakeQuestion
+                  key={intakeQuestionKey}
+                  intakeQuestionEl={intakeQuestionEl}
+                  intakeQuestionKey={intakeQuestionKey}
+                  wholeQuestion={wholeQuestion}
+                  intakeQuestionsInvalid={intakeQuesionsInvalid}
+                  intakeQuestionIdx={intakeQuestionIdx}
+                  collection={collection}
+                  setCollection={setCollection}
+                  formFieldGroup={formFieldGroup}
+                />
+              )}
             </>
           );
         }

--- a/components/VideoIntakeQuestions/index.tsx
+++ b/components/VideoIntakeQuestions/index.tsx
@@ -77,39 +77,46 @@ const VideoIntakeQuestions: React.FC<{
         (intakeQuestionEl, intakeQuestionKey, wholeQuestion) => {
           return (
             <>
-              {intakeQuestionKey === "label" && (
-                <>
-                  <Typography style={{ marginBottom: 10 }}>
-                    {"Question " + (intakeQuestionIdx + 1) + ". "}
-                  </Typography>
-                  {wholeQuestion?.label !== "URL" && ( // URL must be required for video intake per https://github.com/users/Atticus29/projects/1/views/4?pane=issue&itemId=27661393
-                    <Button
-                      style={{ marginBottom: 10 }}
-                      data-testid={"collection-details-submit-button"}
-                      variant="contained"
-                      onClick={() => {
-                        deleteIntakeQuestion(intakeQuestionIdx);
-                      }}
-                    >
-                      <FormattedMessage
-                        id="REMOVE_QUESTION"
-                        defaultMessage="Remove this question"
-                      />
-                    </Button>
-                  )}
-                </>
+              <>
+                {intakeQuestionKey === "label" && (
+                  <>
+                    <Typography style={{ marginBottom: 10 }}>
+                      {"Question " + (intakeQuestionIdx + 1) + ". "}
+                    </Typography>
+
+                    {!wholeQuestion?.isACoreQuestion && (
+                      <Button
+                        style={{ marginBottom: 10 }}
+                        data-testid={"collection-details-submit-button"}
+                        variant="contained"
+                        onClick={() => {
+                          deleteIntakeQuestion(intakeQuestionIdx);
+                        }}
+                      >
+                        <FormattedMessage
+                          id="REMOVE_QUESTION"
+                          defaultMessage="Remove this question"
+                        />
+                      </Button>
+                    )}
+                  </>
+                )}
+              </>
+              {(!wholeQuestion?.isACoreQuestion ||
+                (intakeQuestionKey === "label" &&
+                  wholeQuestion?.isACoreQuestion)) && (
+                <SingleVideoIntakeQuestion
+                  key={intakeQuestionKey}
+                  intakeQuestionEl={intakeQuestionEl}
+                  intakeQuestionKey={intakeQuestionKey}
+                  wholeQuestion={wholeQuestion}
+                  intakeQuestionsInvalid={intakeQuesionsInvalid}
+                  intakeQuestionIdx={intakeQuestionIdx}
+                  collection={collection}
+                  setCollection={setCollection}
+                  formFieldGroup={formFieldGroup}
+                />
               )}
-              <SingleVideoIntakeQuestion
-                key={intakeQuestionKey}
-                intakeQuestionEl={intakeQuestionEl}
-                intakeQuestionKey={intakeQuestionKey}
-                wholeQuestion={wholeQuestion}
-                intakeQuestionsInvalid={intakeQuesionsInvalid}
-                intakeQuestionIdx={intakeQuestionIdx}
-                collection={collection}
-                setCollection={setCollection}
-                formFieldGroup={formFieldGroup}
-              />
             </>
           );
         }

--- a/dummy_data/dummyCollection.tsx
+++ b/dummy_data/dummyCollection.tsx
@@ -43,6 +43,7 @@ const firstQuestion: SingleFormField = {
   invalidInputMessage: "MUST_BE_VALID_URL",
   validatorMethods: [isValidUrl],
   shouldBeCheckboxes: ["isRequired"],
+  isACoreQuestion: true,
 };
 
 const secondQuestion: SingleFormField = {
@@ -324,7 +325,7 @@ const ageClassIndividualQuestion: SingleFormField = {
 };
 
 const moveNameQuestion: SingleFormField = {
-  label: "Move Name",
+  label: "Name of event",
   type: "Autocomplete",
   language: "English",
   isRequired: true,
@@ -335,6 +336,7 @@ const moveNameQuestion: SingleFormField = {
   invalidInputMessage: "INPUT_INVALID",
   autocompleteOptions: [...moveNames],
   usersCanAddCustomOptions: true,
+  isACoreQuestion: true,
 };
 
 const startingPositionOfActor: SingleFormField = {

--- a/dummy_data/dummyCollection.tsx
+++ b/dummy_data/dummyCollection.tsx
@@ -325,7 +325,7 @@ const ageClassIndividualQuestion: SingleFormField = {
 };
 
 const moveNameQuestion: SingleFormField = {
-  label: "Name of event",
+  label: "Name of move",
   type: "Autocomplete",
   language: "English",
   isRequired: true,

--- a/lang/en.json
+++ b/lang/en.json
@@ -67,7 +67,7 @@
   "TOTAL_NET_POINTS_EARNED_THIS_MONTH": "Total net points earned this month",
   "TOTAL_NET_CUMULATIVE_POINTS_EARNED": "Total net cumulative points earned",
   "SUBMIT": "Submit",
-  "COLLECTIONS": "My Collections",
+  "MY_COLLECTIONS": "My Collections",
   "VIEW": "View",
   "EDIT": "Edit",
   "PUBLIC_COLLECTIONS": "Public Collections",
@@ -142,5 +142,6 @@
   "ADD_INDIVIDUAL_TO_VIDEO": "Click rows to attach {individualName} or {individualNamePlural} to {videoName}",
   "MUST_SELECT_AT_LEAST_ONE_INDIVIDUAL": "You must select at least one individual",
   "CLOSE": "Close",
-  "INDIVIDUALS_NOT_FOUND": "Individuals not found"
+  "INDIVIDUALS_NOT_FOUND": "Individuals not found",
+  "COLLECTIONS": "Collections"
 }

--- a/pages/collections/index.tsx
+++ b/pages/collections/index.tsx
@@ -13,10 +13,11 @@ import {
   sanitizeString,
 } from "../../utilities/textUtils";
 import useGetCollections from "../../hooks/useGetCollections";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import router from "next/router";
 
 const Collections: React.FC = () => {
+  const intl: IntlShape = useIntl();
   const [localError, setLocalError] = useState<string>("");
   const { user, authError } = useFirebaseAuth();
   const { isLoading, isError, data, errorMsg } = useGetCollections(
@@ -78,13 +79,17 @@ const Collections: React.FC = () => {
   const handleNewCollectionClick: () => void = () => {
     router.push("/collection/new");
   };
+  const tableTitle: string = intl.formatMessage({
+    id: "COLLECTIONS",
+    defaultMessage: "Collections",
+  });
 
   return (
     <>
       {!isLoading && !isError && !localError! && (
         <>
           <DataTable
-            tableTitle="Testing"
+            tableTitle={tableTitle}
             data={dataWithActions}
             colNamesToDisplay={collectionDisplayCols || defaultDisplayCols}
             actionButtonsToDisplay={{ edit: "Edit", view: "View" }}

--- a/pages/me/index.tsx
+++ b/pages/me/index.tsx
@@ -173,7 +173,7 @@ const Me: React.FC = () => {
       <Grid item sm={12} md={6}>
         <CollectionsPanel
           key={"COLLECTIONS"}
-          titleId={"COLLECTIONS"}
+          titleId={"MY_COLLECTIONS"}
           titleDefault={"My Collections"}
           collectionData={shamMyCollectionData}
           colNamesToDisplay={{ name: "Name" }}

--- a/types.ts
+++ b/types.ts
@@ -45,6 +45,7 @@ export interface SingleFormField {
   autocompleteOptions?: string[];
   usersCanAddCustomOptions?: boolean;
   autocompleteExtras?: {};
+  isACoreQuestion?: boolean;
 }
 
 // export interface QuestionValidity {


### PR DESCRIPTION
…uestion and give eventName and videoUrl that attribute

# Description

Make only the label editable for any question with attribute isACoreQuestion, which is is videoUrl and eventName.

Pull request checklist:

- [x] Features and bugfixes should be PRed into the `develop` branch, **not** `main`
- [x] All text is internationalized
- [x] There are no linter errors
- [x] New features support all states (loading, error, etc)
- [ ] New features look aesthetically pleasing both full screen and with small or mobile screens


Which GitHub issue(s), if any does this PR address?
- [https://github.com/Atticus29/video-annotator/issues/90](https://github.com/Atticus29/video-annotator/issues/90)

Thanks for keeping it clean! Feel free to merge your own pull request after it has been approved - just use the "squash & merge" option.
